### PR TITLE
Added go_version to INFO messages

### DIFF
--- a/src/ngx_nats_comm.c
+++ b/src/ngx_nats_comm.c
@@ -541,6 +541,12 @@ ngx_nats_parse_info(ngx_nats_connection_t *nc, ngx_str_t *bytes,
             }
             nc->srv_max_payload = (ngx_int_t)f->value.value.vint;
         }
+        else if (ngx_strcasecmp(name, (u_char *)"go") == 0) {
+            if (f->value.type != NGX_NATS_JSON_STRING) {
+                return NGX_ERROR;
+            }
+            nc->go_version = f->value.value.vstr;   /* in pool */
+        }
         else {
             return NGX_ERROR;
         }

--- a/src/ngx_nats_comm.h
+++ b/src/ngx_nats_comm.h
@@ -71,6 +71,7 @@ typedef struct {
     ngx_str_t              *srv_host;
     ngx_int_t               srv_port;
     ngx_str_t              *srv_version;
+    ngx_str_t              *go_version;
     ngx_int_t               srv_max_payload;
     unsigned                srv_auth_required:1;
     unsigned                srv_ssl_required:1;


### PR DESCRIPTION
The nginx-nats client was being restrictive and failing because of the new field (go_version) added to the INFO messages

@wallyqs @zquestz @derekcollison 
