### PR TITLE
[ADDED] Support for NGINX dynamic module

### DIFF
--- a/src/config
+++ b/src/config
@@ -4,8 +4,10 @@ USE_OPENSSL=YES
 
 if test -n "$ngx_module_link"; then
     ngx_module_type=CORE
+    
     ngx_module_name="ngx_nats_module \
                      ngx_nats_core_module"
+                     
     ngx_module_srcs="$ngx_addon_dir/ngx_nats.c \
                      $ngx_addon_dir/ngx_nats_comm.c \
                      $ngx_addon_dir/ngx_nats_protocol.c \

--- a/src/config
+++ b/src/config
@@ -1,12 +1,33 @@
-CORE_INCS="$CORE_INCS $ngx_addon_dir"
 ngx_addon_name=ngx_nats_module
+CORE_INCS="$CORE_INCS $ngx_addon_dir"
 USE_OPENSSL=YES
-HTTP_MODULES="$HTTP_MODULES ngx_nats_module ngx_nats_core_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_nats.c"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_nats_comm.c"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_nats_protocol.c"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_nats_json.c"
-NGX_ADDON_DEPS="$NGX_ADDON_DEPS $ngx_addon_dir/ngx_nats.h"
-NGX_ADDON_DEPS="$NGX_ADDON_DEPS $ngx_addon_dir/ngx_nats_comm.h"
-NGX_ADDON_DEPS="$NGX_ADDON_DEPS $ngx_addon_dir/ngx_nats_protocol.h"
-NGX_ADDON_DEPS="$NGX_ADDON_DEPS $ngx_addon_dir/ngx_nats_json.h"
+
+if test -n "$ngx_module_link"; then
+    ngx_module_type=CORE
+    ngx_module_name="ngx_nats_module \
+                     ngx_nats_core_module"
+    ngx_module_srcs="$ngx_addon_dir/ngx_nats.c \
+                     $ngx_addon_dir/ngx_nats_comm.c \
+                     $ngx_addon_dir/ngx_nats_protocol.c \
+                     $ngx_addon_dir/ngx_nats_json.c"
+
+    ngx_module_deps="$ngx_addon_dir/ngx_nats.h \
+                     $ngx_addon_dir/ngx_nats_comm.h \
+                     $ngx_addon_dir/ngx_nats_protocol.h \
+                     $ngx_addon_dir/ngx_nats_json.h"
+
+    ngx_module_order="ngx_nats_module \
+                      ngx_nats_core_module"                 
+
+    . auto/module
+else
+    HTTP_MODULES="$HTTP_MODULES ngx_nats_module ngx_nats_core_module"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_nats.c"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_nats_comm.c"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_nats_protocol.c"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_nats_json.c"
+    NGX_ADDON_DEPS="$NGX_ADDON_DEPS $ngx_addon_dir/ngx_nats.h"
+    NGX_ADDON_DEPS="$NGX_ADDON_DEPS $ngx_addon_dir/ngx_nats_comm.h"
+    NGX_ADDON_DEPS="$NGX_ADDON_DEPS $ngx_addon_dir/ngx_nats_protocol.h"
+    NGX_ADDON_DEPS="$NGX_ADDON_DEPS $ngx_addon_dir/ngx_nats_json.h"
+fi


### PR DESCRIPTION
Updating the module config to add the new configuration syntax for dynamic modules.  The refactor was based primarily on the [converting guide](https://www.nginx.com/resources/wiki/extending/converting) provided by NGINX.

While this successfully generates the new dynamic module - we're seeing a segmentation fault while reading the NATS server configuration.  Still digging into the cause - but including this WIP PR with the hope that someone might be able to help us troubleshoot.

**Segmentation Fault**
```
root@abdc4db265d8:/# gdb nginx
...
(gdb) set args -c /etc/nginx/conf/nginx.conf
(gdb) run
Starting program: /usr/sbin/nginx -c /etc/nginx/conf/nginx.conf
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

Program received signal SIGSEGV, Segmentation fault.
0x00005555555867e0 in ngx_palloc ()

(gdb) backtrace
#0  0x00005555555867e0 in ngx_palloc ()
#1  0x0000555555586b1d in ngx_array_create ()
#2  0x00007ffff5242a8c in ngx_nats_core_server (cf=0x7fffffffe220, cmd=<optimized out>, conf=0x555555923a88)
    at /tmp/nginx-nats-master/src/ngx_nats.c:511
#3  0x0000555555599411 in ngx_conf_parse ()
#4  0x00007ffff5242255 in ngx_nats_block (cf=0x7fffffffe220, cmd=<optimized out>, conf=<optimized out>)
    at /tmp/nginx-nats-master/src/ngx_nats.c:288
#5  0x0000555555599411 in ngx_conf_parse ()
#6  0x0000555555596b0c in ngx_init_cycle ()
#7  0x0000555555583f0b in main ()
``` 

**NGINX configuration**
```
load_module /usr/local/nginx/modules/ngx_nats_module.so;

nats {
  server localhost:4222;

  reconnect 2s;
  ping      30s;
}
```