### PR TITLE
Add Lev Brouk as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,3 +5,6 @@ Maintainership is on a per project basis.
 ### Core-maintainers
   - Ivan Kozlovic <ivan@nats.io> [@kozlovic](https://github.com/kozlovic)
   - Derek Collison <derek@nats.io> [@derekcollison](https://github.com/derekcollison)
+
+### Maintainers
+  - Lev Brouk <levbrouk@gmail.com> [@levb](https://github.com/levb)


### PR DESCRIPTION
Add @levb as a maintainer.  Lev already has write access.

Signed-off-by: Colin Sullivan <colin@synadia.com>